### PR TITLE
Upgrade dependency gem vcr from 4.x to 5.x

### DIFF
--- a/cassette-rack.gemspec
+++ b/cassette-rack.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'kramdown', '~> 2.1'
   spec.add_dependency 'liquid', '~> 4.0'
   spec.add_dependency 'rack', '~> 2.0'
-  spec.add_dependency 'vcr', '~> 4.0'
+  spec.add_dependency 'vcr', '~> 5.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/lib/cassette-rack/version.rb
+++ b/lib/cassette-rack/version.rb
@@ -1,3 +1,3 @@
 module CassetteRack
-  VERSION = '0.9.0'.freeze
+  VERSION = '0.10.0'.freeze
 end


### PR DESCRIPTION
### 背景

- `cassette-rack` は `vcr` に依存しているが、現状 `4.x` に固定されている。
- Ruby 2.5 および 2.6 は `vcr 5.x` でサポートされたため、バージョンアップを行いたい。
    - https://github.com/vcr/vcr/blob/master/CHANGELOG.md

### 確認内容

- 使用しているライブラリにて `rackup` を行い、正常に UI が表示され、操作できることを確認しました。
- RSpec が成功することを確認しました。
